### PR TITLE
fix: correct ARC CRD URL in runner deployment script

### DIFF
--- a/apply_crds_then_deploy_runner.sh
+++ b/apply_crds_then_deploy_runner.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+echo "\U0001F4E5 Downloading and applying ARC CRDs from GitHub..."
+curl -L https://raw.githubusercontent.com/actions/actions-runner-controller/v0.27.1/config/crd/bases/actions.summerwind.dev_runnersets.yaml | kubectl apply -f -
+
+echo "\u23F3 Waiting for RunnerSet CRD to become available..."
+until kubectl get crd runnersets.actions.summerwind.dev &>/dev/null; do
+  echo "\u231B Still waiting for CRD..."
+  sleep 2
+done
+
+echo "\u2705 CRD is ready. Deploying runner manifest..."
+kubectl apply -f ~/runner-deployment.yaml
+
+echo "\u2705 RunnerSet successfully deployed!"


### PR DESCRIPTION
## Summary
- fix runner deployment script to download current RunnerSet CRD
- wait for runnersets CRD before applying runner manifest

## Testing
- `shellcheck apply_crds_then_deploy_runner.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e0bcf3b808330a00df59fa0ed0761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a script to automate applying required resources and deploying the runner, with clear status messages and visual indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->