### PR TITLE
ci: enable auto-merge for bot PRs

### DIFF
--- a/.github/workflows/auto-merge-codex.yml
+++ b/.github/workflows/auto-merge-codex.yml
@@ -1,0 +1,47 @@
+name: Auto-merge bot PRs
+
+on:
+  pull_request_target:
+    types: [opened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: >-
+      github.event.action == 'opened' &&
+      github.event.pull_request.base.ref == 'main' &&
+      (github.event.pull_request.user.login == 'codex[bot]' ||
+       github.event.pull_request.user.login == 'github-actions[bot]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: merge
+      - name: Add auto-merge label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-label auto-merge
+      - name: Comment auto-merge
+        if: github.event.pull_request.user.login == 'codex[bot]'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment ${{ github.event.pull_request.number }} --body 'Codex-generated fix. Auto-merging if checks pass.'
+
+  sync-merged:
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      (github.event.pull_request.user.login == 'codex[bot]' ||
+       github.event.pull_request.user.login == 'github-actions[bot]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sync_merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api repos/${{ github.repository }}/dispatches -f event_type=sync_merge

--- a/.github/workflows/auto-merge-codex.yml
+++ b/.github/workflows/auto-merge-codex.yml
@@ -1,8 +1,8 @@
 name: Auto-merge bot PRs
 
 on:
-  pull_request_target:
-    types: [opened, closed]
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
 
 permissions:
   contents: write
@@ -11,7 +11,9 @@ permissions:
 jobs:
   enable-auto-merge:
     if: >-
-      github.event.action == 'opened' &&
+      (github.event.action == 'opened' ||
+       github.event.action == 'reopened' ||
+       github.event.action == 'synchronize') &&
       github.event.pull_request.base.ref == 'main' &&
       (github.event.pull_request.user.login == 'codex[bot]' ||
        github.event.pull_request.user.login == 'github-actions[bot]')
@@ -27,7 +29,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit ${{ github.event.pull_request.number }} --add-label auto-merge
       - name: Comment auto-merge
-        if: github.event.pull_request.user.login == 'codex[bot]'
+        if: >-
+          github.event.action == 'opened' &&
+          github.event.pull_request.user.login == 'codex[bot]'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr comment ${{ github.event.pull_request.number }} --body 'Codex-generated fix. Auto-merging if checks pass.'


### PR DESCRIPTION
## Summary
- automatically merge codex and GitHub Actions PRs targeting `main`
- label and comment codex PRs for auto-merge
- trigger `sync_merge` dispatch after auto-merge

## Testing
- `pre-commit run --config AutoGPT/.pre-commit-config.yaml --files .github/workflows/auto-merge-codex.yml`


------
https://chatgpt.com/codex/tasks/task_e_688e0010a5c883308c4e714ac549938a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced an automated workflow to enable auto-merge for pull requests opened by specific bots and trigger synchronization actions after such pull requests are merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->