### PR TITLE
Fix auto-merge workflow to include Dependabot

### DIFF
--- a/.github/workflows/auto-merge-codex.yml
+++ b/.github/workflows/auto-merge-codex.yml
@@ -10,7 +10,14 @@ permissions:
 
 jobs:
   enable-auto-merge:
-    if: github.event.pull_request.base.ref == 'main' && (github.event.pull_request.user.login == 'codex[bot]' || github.event.pull_request.user.login == 'github-actions[bot]')
+    # Allow auto-merging PRs opened by codex[bot], github-actions[bot] or dependabot[bot]
+    if: >
+      github.event.pull_request.base.ref == 'main' &&
+      (
+        github.event.pull_request.user.login == 'codex[bot]' ||
+        github.event.pull_request.user.login == 'github-actions[bot]' ||
+        github.event.pull_request.user.login == 'dependabot[bot]'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge


### PR DESCRIPTION
## Summary
- allow auto-merging for dependabot PRs in auto-merge workflow

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: ModuleNotFoundError: ldclient, pydantic, dotenv, networkx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688f2ea7d52883309f1ed1e80df265b5