### PR TITLE
refactor(benchmark): remove deprecated blocks

### DIFF
--- a/AutoGPT/classic/benchmark/agbenchmark/__main__.py
+++ b/AutoGPT/classic/benchmark/agbenchmark/__main__.py
@@ -51,13 +51,6 @@ def cli(
     configure_logging(logging.DEBUG if debug else logging.INFO)
 
 
-@cli.command(hidden=True)
-def start():
-    raise DeprecationWarning(
-        "`agbenchmark start` is deprecated. Use `agbenchmark run` instead."
-    )
-
-
 @cli.command(default=True)
 @click.option(
     "-N", "--attempts", default=1, help="Number of times to run each challenge."

--- a/AutoGPT/classic/benchmark/agbenchmark/app.py
+++ b/AutoGPT/classic/benchmark/agbenchmark/app.py
@@ -47,8 +47,6 @@ logger.debug("Loading challenges...")
 while challenge_spec_files:
     challenge_spec_file = Path(challenge_spec_files.popleft())
     challenge_relpath = challenge_spec_file.relative_to(challenges_path.parent)
-    if challenge_relpath.is_relative_to("challenges/deprecated"):
-        continue
 
     logger.debug(f"Loading {challenge_relpath}...")
     try:

--- a/AutoGPT/classic/benchmark/agbenchmark/challenges/builtin.py
+++ b/AutoGPT/classic/benchmark/agbenchmark/challenges/builtin.py
@@ -69,9 +69,9 @@ class BuiltinChallengeSpec(BaseModel):
         class Eval(BaseModel):
             type: str
             scoring: Optional[Literal["percentage", "scale", "binary"]] = None
-            template: Optional[
-                Literal["rubric", "reference", "question", "custom"]
-            ] = None
+            template: Optional[Literal["rubric", "reference", "question", "custom"]] = (
+                None
+            )
             examples: Optional[str] = None
 
             @field_validator("scoring", "template")
@@ -228,9 +228,11 @@ class BuiltinChallenge(BaseChallenge):
         request.node.user_properties.append(
             (
                 "answers",
-                [r.result for r in eval_results]
-                if request.config.getoption("--keep-answers")
-                else None,
+                (
+                    [r.result for r in eval_results]
+                    if request.config.getoption("--keep-answers")
+                    else None
+                ),
             )
         )
         request.node.user_properties.append(("scores", [r.score for r in eval_results]))
@@ -451,7 +453,4 @@ def load_builtin_challenges() -> Iterator[type[BuiltinChallenge]]:
 
 
 def _challenge_should_be_ignored(json_file_path: Path):
-    return (
-        "challenges/deprecated" in json_file_path.as_posix()
-        or "challenges/library" in json_file_path.as_posix()
-    )
+    return "challenges/library" in json_file_path.as_posix()


### PR DESCRIPTION
## Changes
- drop deprecated `agbenchmark start` command
- remove unused challenge skip for deprecated paths
- simplify builtin challenge ignore list

## Testing
- `poetry run format` *(fails: Command not found)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'agbenchmark.reports')*


------
https://chatgpt.com/codex/tasks/task_e_68913cf31ec883308722b6088867d016